### PR TITLE
v1.3.0: LatestRelease <- Development

### DIFF
--- a/service_test.go
+++ b/service_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func ExampleNewService() {
-	service := ggservice.NewService("My Service", 5*time.Second)
+	service := ggservice.NewService("My Service", 5*time.Second, nil)
 
-	ExampleStart := func() error {
+	ExampleStart := func(args ...any) error {
 		fmt.Println("this runs when service starts")
 		return nil
 	}
@@ -33,9 +33,9 @@ func ExampleNewService() {
 }
 
 func ExampleNew() {
-	service := ggservice.New(&ggservice.Service{Name: "My Service", GracefulShutdownTime: 5 * time.Second})
+	service := ggservice.New(&ggservice.Service{Name: "My Service", GracefulShutdownTime: 5 * time.Second, Args: nil})
 
-	ExampleStart := func() error {
+	ExampleStart := func(args ...any) error {
 		fmt.Println("this runs when service starts")
 		return nil
 	}


### PR DESCRIPTION
Fixed signature of functions, so that start has arguments that can be used, if passed along when creating a new service
Skipping v 1.2.0 as 1.1.2 is breaking change (1.1.2 is alias for 1.2.0)